### PR TITLE
Derive Clone for ByteStream and Token

### DIFF
--- a/src/backpressure.rs
+++ b/src/backpressure.rs
@@ -74,6 +74,7 @@ pub struct Sender {
 }
 
 /// The token which holds onto a single resource item
+#[derive(Clone)]
 pub struct Token {
     inner: Arc<Inner>,
 }

--- a/src/byte_stream.rs
+++ b/src/byte_stream.rs
@@ -12,7 +12,7 @@ use async_std::net::{TcpStream, Shutdown};
 use crate::backpressure::Token;
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum Stream {
     Tcp(TcpStream),
     #[cfg(unix)]
@@ -48,7 +48,7 @@ pub enum PeerAddr {
 ///
 /// The structure implements AsyncRead and AsyncWrite so can be used for
 /// protocol implementation directly.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ByteStream {
     stream: Stream,
     token: Option<Token>,

--- a/src/byte_stream.rs
+++ b/src/byte_stream.rs
@@ -48,6 +48,13 @@ pub enum PeerAddr {
 ///
 /// The structure implements AsyncRead and AsyncWrite so can be used for
 /// protocol implementation directly.
+///
+/// # Notes on Cloning
+///
+/// Cloning a `ByteStream` is a shallow clone, both resulting `ByteStream`
+/// structures hold the same backpressure token (and the same underlying OS socket).
+/// The backpressure slot will be freed (which means new connection can be accepted)
+/// when the last clone of `ByteStream` is dropped.
 #[derive(Debug, Clone)]
 pub struct ByteStream {
     stream: Stream,


### PR DESCRIPTION
This will allow tide to use async-listen with async-h1, which has a Clone bound